### PR TITLE
Fix intrinsicContentSize

### DIFF
--- a/AttributedLabel/AttributedLabel.swift
+++ b/AttributedLabel/AttributedLabel.swift
@@ -159,7 +159,7 @@ open class AttributedLabel: UIView {
 
     open override var intrinsicContentSize: CGSize {
         if usesIntrinsicContentSize {
-            let width = preferredMaxLayoutWidth == 0 ? CGFloat.greatestFiniteMagnitude : preferredMaxLayoutWidth
+            let width = preferredMaxLayoutWidth == 0 ? bounds.width : preferredMaxLayoutWidth
             let size = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
             return sizeThatFits(size)
         } else {

--- a/AttributedLabelTests/AttributedLabelTests.swift
+++ b/AttributedLabelTests/AttributedLabelTests.swift
@@ -49,7 +49,7 @@ class AttributedLabelTests: XCTestCase {
 
     func testContentSize() {
         let attributedLabel = AttributedLabel(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)))
-        let tallestSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        let tallestSize = CGSize(width: attributedLabel.bounds.width, height: CGFloat.greatestFiniteMagnitude)
 
         attributedLabel.usesIntrinsicContentSize = true
         XCTAssertEqual(attributedLabel.intrinsicContentSize, .zero)


### PR DESCRIPTION
If preferredMaxLayoutWidth is not specified, width of intrinsicContentSize is modified to use bounds.width.